### PR TITLE
Add interactive shell mode

### DIFF
--- a/Sources/CL10/CLI/CLI.swift
+++ b/Sources/CL10/CLI/CLI.swift
@@ -21,6 +21,7 @@ final class CLI {
         // Management / local-process commands
         switch sub {
         case "watch": return runWatch()
+        case "shell": return CLIShell(cli: self).run()
         case "version": return showVersion()
         case "quit": return talk("QUIT")
         case "help":
@@ -209,6 +210,7 @@ final class CLI {
             Usage: cl10 <command> [args]
 
               watch               Start the watcher (foreground)
+              shell               Start interactive shell
               0..9                Copy entry at index N (digit shortcut)
               list                Show indices with previews
               find "q"            Show only entries matching q (canonical indices)

--- a/Sources/CL10/CLI/CLIShell.swift
+++ b/Sources/CL10/CLI/CLIShell.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+final class CLIShell {
+    private let cli: CLI
+
+    init(cli: CLI) {
+        self.cli = cli
+    }
+
+    func run() -> ExitCode {
+        while true {
+            FileHandle.standardOutput.write(Data("cl10> ".utf8))
+            guard let line = readLine() else { break }
+            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmed.isEmpty { continue }
+            if trimmed == "exit" || trimmed == "quit" { break }
+            let parts = Self.tokenize(trimmed)
+            if parts.first == "shell" { continue }
+            _ = cli.run(args: parts)
+        }
+        return .ok
+    }
+
+    private static func tokenize(_ line: String) -> [String] {
+        var args: [String] = []
+        var current = ""
+        var inQuotes = false
+        var escape = false
+        for ch in line {
+            if escape {
+                current.append(ch)
+                escape = false
+            } else if ch == "\\" {
+                escape = true
+            } else if ch == "\"" {
+                inQuotes.toggle()
+            } else if ch.isWhitespace && !inQuotes {
+                if !current.isEmpty {
+                    args.append(current)
+                    current = ""
+                }
+            } else {
+                current.append(ch)
+            }
+        }
+        if !current.isEmpty {
+            args.append(current)
+        }
+        return args
+    }
+}


### PR DESCRIPTION
## Summary
- add an interactive shell that accepts the same commands as the CLI
- expose the shell via a new `shell` subcommand and document it in usage

## Testing
- `swift build` *(fails: no such module 'Darwin')*


------
https://chatgpt.com/codex/tasks/task_e_68ad8b9678f4832eaef3195bf2d83382